### PR TITLE
Complete implementation for ft_strcmp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.o
+libasm.a
+test

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ NAME = libasm.a
 
 SRCS = ft_strlen.s\
 			 ft_strcpy.s\
-			 # ft_strcmp.s\
+			 ft_strcmp.s\
 
 # Concaténation des fichiers source de base et supplémentaires
 ALL_SRCS = $(SRCS) $(BONUS_SRCS)
@@ -36,6 +36,7 @@ clean_bonus:
 
 fclean: clean
 	rm -f $(NAME)
+	rm -f test
 
 re: fclean all
 

--- a/ft_strcmp.s
+++ b/ft_strcmp.s
@@ -1,0 +1,26 @@
+bits 64
+global ft_strcmp
+
+
+section .text
+  ft_strcmp:
+    xor rbx, rbx; rbx = 0
+    ;rdi = dest, rsi = src
+ 
+  .loop:
+    cmp byte [rsi + rbx], 0 ; je check si je suis sur un \0
+    je .done ; si je suis dessus je passe a l'etape suivante
+    mov al, [rsi + rbx] ; je stock le caracter actuel de src(rsi) dans al
+    cmp [rdi + rbx], al ; je compare les deux caracters actuel
+    jne .err ; si != je renvoie err
+    inc rbx ; incremente rbx (index)
+    jmp .loop ; je refais un tour
+
+  .done: 
+    mov rax, 0
+    ret
+
+  .err:
+    mov rax, [rdi + rbx] 
+    sub rax, [rsi + rbx] ; dest = dest - src
+    ret

--- a/tests/test.c
+++ b/tests/test.c
@@ -19,6 +19,10 @@ int assert_str(const char *a, const char *b) {
   return strcmp(a, b) == 0;
 }
 
+int assert_cmp(int a, int b) {
+  return a == 0 && b == 0;
+}
+
 
 void strlen_tests() {
 
@@ -61,38 +65,38 @@ void strcpy_tests() {
     printf("\n");
 }
 
-// void strcmp_tests() {
-//   printf("--------[STRCMP_TESTS]--------\n");
-//   const char *tests[] = {
-//         "",
-//         "a",
-//         "hello",
-//         "oui je test",
-//         "longue chaine avec beaucoup de caracteres...",
-//         NULL
-//     };
-//
-//     const char *tests2[] = {
-//         "",
-//         "a",
-//         "heilo",
-//         "oui je test",
-//         "longue/chaine avec beaucoup de caracteres...",
-//         NULL
-//     };
-//     for (int i = 0; tests[i] != NULL; i++) {
-//         int mine = ft_strcmp(tests[i], tests2[i]);
-//         int real = strcmp(tests[i], tests2[i]);
-//         printf("%s: ", tests[i]);
-//         ASSERT(assert_int(mine, real));
-//     }
-//     printf("\n");
-// }
+void strcmp_tests() {
+  printf("--------[STRCMP_TESTS]--------\n");
+  const char *tests[] = {
+        "",
+        "a",
+        "hello",
+        "oui je test",
+        "longue chaine avec beaucoup de caracteres...",
+        NULL
+    };
+
+    const char *tests2[] = {
+        "",
+        "a",
+        "heilo",
+        "oui je test",
+        "longue/chaine avec beaucoup de caracteres...",
+        NULL
+    };
+    for (int i = 0; tests[i] != NULL; i++) {
+        int mine = ft_strcmp(tests[i], tests2[i]);
+        int real = strcmp(tests[i], tests2[i]);
+        printf("%s: ", tests[i]);
+        ASSERT(assert_int(mine, real));
+    }
+    printf("\n");
+}
 
 
 int main(void) {
     strlen_tests();
     strcpy_tests();
-    // strcmp_tests();
+    strcmp_tests();
     return 0;
 }


### PR DESCRIPTION
This pull request adds the implementation of `ft_strcmp` in assembly, integrates it into the build process, and enables its testing in the test suite. The changes ensure that `ft_strcmp` is now built, tested, and cleaned up properly, improving both coverage and maintainability.

**Assembly implementation and integration:**

* Added a new `ft_strcmp.s` file containing the assembly implementation of `ft_strcmp`.
* Enabled building `ft_strcmp.s` by including it in the `SRCS` variable in the `Makefile`.

**Testing improvements:**

* Un-commented and enabled the `strcmp_tests` function in `tests/test.c` to test `ft_strcmp` against the standard `strcmp`.
* Added a new helper function `assert_cmp` in `tests/test.c` to assist with integer comparisons in tests.

**Build and cleanup enhancements:**

* Updated the `fclean` target in the `Makefile` to also remove the `test` binary, ensuring a clean build environment.