### PR TITLE
Func/ft strcmp

### DIFF
--- a/ft_strcmp.s
+++ b/ft_strcmp.s
@@ -4,6 +4,7 @@ global ft_strcmp
 
 section .text
   ft_strcmp:
+    push rbx
     xor rbx, rbx; rbx = 0
     ;rdi = dest, rsi = src
  
@@ -17,10 +18,12 @@ section .text
     jmp .loop ; je refais un tour
 
   .done: 
+    pop rbx
     mov rax, 0
     ret
 
   .err:
-    mov rax, [rdi + rbx] 
+    mov rax, [rdi + rbx]
     sub rax, [rsi + rbx] ; dest = dest - src
+    pop rbx
     ret

--- a/ft_strcpy.s
+++ b/ft_strcpy.s
@@ -4,6 +4,7 @@ global ft_strcpy
 
 section .text
   ft_strcpy:
+    push rbx ; sauvegarde de la valeur dans la stack
     xor rbx, rbx; rbx = 0
     ;rdi = dest, rsi = src
  
@@ -18,4 +19,5 @@ section .text
   .done: 
     mov byte [rdi + rbx], 0
     mov rax, rdi
+    pop rbx ; on remet la valeur
     ret

--- a/ft_strlen.s
+++ b/ft_strlen.s
@@ -3,6 +3,7 @@ global ft_strlen
 
 section .text
   ft_strlen:
+    push rbx
     xor rbx, rbx
    
   len_loop:
@@ -14,5 +15,6 @@ section .text
 
 
   len_done:
+    pop rbx
     mov rax, rbx
     ret

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,36 @@
+# libasm
+
+This project aims to reimplement certain standard C library functions in **x86_64 assembly (NASM)**.  
+It helps to get familiar with assembly language, register management, Linux system calls (`syscall`), and basic assembly debugging.
+
+---
+
+## Implemented Functions
+
+Currently, the following functions are available:
+
+- **ft_strlen.s**: returns the length of a string (equivalent to `strlen`).
+- **ft_strcpy.s**: copies a string into another (equivalent to `strcpy`).
+- **ft_strcmp.s**: compares two strings (equivalent to `strcmp`).
+- **ft_write.s**: writes data to a file descriptor (equivalent to `write`).
+
+---
+
+## Useful Resources
+
+Here are some useful resources to improve your understanding:
+
+- [Registers (x86_64 register explanations)](https://math.hws.edu/eck/cs220/f22/registers.html)
+- [Linux System Call Table (x86_64)](https://blog.rchapman.org/posts/Linux_System_Call_Table_for_x86_64/)
+- [GDB Guide for Debugging](https://web.cecs.pdx.edu/~apt/cs510comp/gdb.pdf)
+- [x86 Instruction Documentation](https://www.felixcloutier.com/x86/)
+
+---
+
+## Notes
+
+- The project follows the **System V AMD64 ABI** convention (standard calling convention on Linux).
+- Each function must respect register usage conventions.
+- Always preserve non-volatile registers (`rbx`, `rbp`, `r12–r15`).
+
+---


### PR DESCRIPTION
This pull request introduces important improvements to the assembly implementations of several standard C library functions by ensuring proper preservation of the non-volatile `rbx` register, and adds a new `readme.md` file with documentation for the project. The main changes are grouped below by theme:

Register preservation improvements:

* Added `push rbx` at the start and `pop rbx` at the end of the `ft_strlen`, `ft_strcpy`, and `ft_strcmp` functions to properly save and restore the non-volatile `rbx` register, ensuring compliance with the System V AMD64 ABI calling convention. 

Documentation:

* Added a new `readme.md` file describing the project, listing implemented functions, and providing useful resources and notes on ABI and register conventions.