### PR TITLE
function: complete implementation for ft_read

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ SRCS = ft_strlen.s\
 			 ft_strcpy.s\
 			 ft_strcmp.s\
 			 ft_write.s\
+			 ft_read.s\
 
 # Concaténation des fichiers source de base et supplémentaires
 ALL_SRCS = $(SRCS) $(BONUS_SRCS)

--- a/ft_read.s
+++ b/ft_read.s
@@ -1,0 +1,21 @@
+bits 64
+global ft_read
+
+extern __errno_location
+
+section .text
+  ft_read:
+    mov rax, 0
+    syscall
+    cmp rax, 0
+    jge .done ; >=
+  
+  .err:
+    mov rdi, rax ; on stock la valeur de rax dans rdi
+    neg rdi  ; rdi = -rax
+    call __errno_location wrt ..plt; __errno_location renvoie l'adrress de errno dans rax
+    mov dword [rax], edi ; on assigne la -valeur retourner par sys_write a errno
+    mov rax, -1
+  
+  .done:
+    ret

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,7 @@ Currently, the following functions are available:
 - **ft_strcpy.s**: copies a string into another (equivalent to `strcpy`).
 - **ft_strcmp.s**: compares two strings (equivalent to `strcmp`).
 - **ft_write.s**: writes data to a file descriptor (equivalent to `write`).
+- **ft_read.s**: read data from a file descriptor (equivalent to `read`).
 
 ---
 

--- a/tests/read_test_mine.txt
+++ b/tests/read_test_mine.txt
@@ -1,0 +1,7 @@
+oui non peut etre
+
+
+
+non
+
+

--- a/tests/read_test_real.txt
+++ b/tests/read_test_real.txt
@@ -1,0 +1,7 @@
+oui non peut etre
+
+
+
+non
+
+

--- a/tests/test.c
+++ b/tests/test.c
@@ -117,11 +117,11 @@ void test_write() {
     }
     close(fd);
     fd = open("/dev/null", O_RDONLY);
-    int mine = ft_write(fd, "ca dois pas marcher", 19);
-    perror("mine errno");
-    int real = write(fd, "ca dois pas marcher", 19);
-    perror("real errno");
     printf("write_in_rdonly_file: ");
+    int mine = ft_write(fd, "ca dois pas marcher", 19);
+    perror("  |__mine errno");
+    int real = write(fd, "ca dois pas marcher", 19);
+    perror("  |__real errno");
     ASSERT(assert_int(mine, real));
     close(fd);
     printf("\n");
@@ -148,11 +148,19 @@ void test_read() {
   (close(mine_fd), close(real_fd));
   mine_fd = open("./tests/read_test_mine.txt", O_WRONLY);
   real_fd = open("./tests/read_test_real.txt", O_WRONLY);
-  mine = ft_read(mine_fd, mine_buf, 15);
-  perror("mine errno");
-  real = ft_read(real_fd, real_buf, 15);
-  perror("real errno");
   printf("read_in_wronly_file: ");
+  mine = ft_read(mine_fd, mine_buf, 15);
+  perror("\tmine errno");
+  real = ft_read(real_fd, real_buf, 15);
+  perror("\treal errno");
+  ASSERT(assert_int(mine, real));
+  (close(mine_fd), close(real_fd));
+  
+  printf("read_in_invalid fd: ");
+  mine = ft_read(mine_fd, mine_buf, 15);
+  perror("  |__mine errno");
+  real = ft_read(real_fd, real_buf, 15);
+  perror("  |__real errno");
   ASSERT(assert_int(mine, real));
   (close(mine_fd), close(real_fd));
   printf("\n");

--- a/tests/test.c
+++ b/tests/test.c
@@ -8,6 +8,7 @@ size_t  ft_strlen(const char *str);
 char    *ft_strcpy(char *dest, const char *src);
 int     ft_strcmp(const char *s1, const char *s2);
 ssize_t ft_write(int fd, const void *buf, size_t count);
+ssize_t ft_read(int fd, void *buf, size_t count);
 
 #define ASSERT(a) { \
   if (a) { printf("ok\n"); } else { printf("failed\n");} \
@@ -126,11 +127,43 @@ void test_write() {
     printf("\n");
 }
 
+void test_read() {
+  int fd = open("/dev/null", O_WRONLY);
+  printf("--------[READ_TESTS]--------\n");
+
+  int  mine_fd = open("./tests/read_test_mine.txt", O_RDONLY);
+  int  real_fd = open("./tests/read_test_real.txt", O_RDONLY);
+  char mine_buf[20] = {0};
+  char real_buf[20] = {0};
+
+  int mine = ft_read(mine_fd, mine_buf, 15);
+  int real = ft_read(real_fd, real_buf, 15);
+
+  printf("read_buf_result: ");
+  ASSERT(assert_str(mine_buf, real_buf));
+
+  printf("read_return_value: ");
+  ASSERT(assert_int(mine, real));
+
+  (close(mine_fd), close(real_fd));
+  mine_fd = open("./tests/read_test_mine.txt", O_WRONLY);
+  real_fd = open("./tests/read_test_real.txt", O_WRONLY);
+  mine = ft_read(mine_fd, mine_buf, 15);
+  perror("mine errno");
+  real = ft_read(real_fd, real_buf, 15);
+  perror("real errno");
+  printf("read_in_wronly_file: ");
+  ASSERT(assert_int(mine, real));
+  (close(mine_fd), close(real_fd));
+  printf("\n");
+}
+
 
 int main(void) {
     strlen_tests();
     strcpy_tests();
     strcmp_tests();
     test_write();
+    test_read();
     return 0;
 }


### PR DESCRIPTION
This pull request adds a new assembly implementation for the `read` function (`ft_read`) and integrates it into the project. It updates the build configuration, documentation, and tests to support and verify the new functionality.

### Addition of `ft_read` function

* Added the assembly source file `ft_read.s` implementing the `read` system call with proper error handling.
* Updated the `Makefile` to include `ft_read.s` in the source files for compilation.

### Documentation and Testing

* Documented the new `ft_read` function in `readme.md`, describing its purpose and equivalence to the standard `read` function.
* Updated the function prototype list in `tests/test.c` to include `ft_read`.
* Added a comprehensive test suite for `ft_read` in `tests/test.c`, including buffer comparison, return value checks, and error handling scenarios.
* Added new test files `read_test_mine.txt` and `read_test_real.txt` with sample data for read function testing.