### PR TITLE
Func/ft strdup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,6 @@ dtests: all
 
 vtests: all
 	gcc -Wall -Wextra -g tests/test.c -L. -lasm -o test -g3
-	valgrind --leak-check=full --show-leak-kinds=all test
+	valgrind --leak-check=full --show-leak-kinds=all ./test
 
 .PHONY: all bonus clean fclean re tests

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SRCS = ft_strlen.s\
 			 ft_strcmp.s\
 			 ft_write.s\
 			 ft_read.s\
+			 ft_strdup.s\
 
 # Concaténation des fichiers source de base et supplémentaires
 ALL_SRCS = $(SRCS) $(BONUS_SRCS)
@@ -45,5 +46,13 @@ re: fclean all
 tests: all
 	gcc -Wall -Wextra -g tests/test.c -L. -lasm -o test -g3
 	./test
+
+dtests: all
+	gcc -Wall -Wextra -g tests/test.c -L. -lasm -o test -g3
+	gdb test
+
+vtests: all
+	gcc -Wall -Wextra -g tests/test.c -L. -lasm -o test -g3
+	valgrind --leak-check=full --show-leak-kinds=all test
 
 .PHONY: all bonus clean fclean re tests

--- a/ft_strcmp.s
+++ b/ft_strcmp.s
@@ -4,26 +4,23 @@ global ft_strcmp
 
 section .text
   ft_strcmp:
-    push rbx
-    xor rbx, rbx; rbx = 0
     ;rdi = dest, rsi = src
  
   .loop:
-    cmp byte [rsi + rbx], 0 ; je check si je suis sur un \0
-    je .done ; si je suis dessus je passe a l'etape suivante
-    mov al, [rsi + rbx] ; je stock le caracter actuel de src(rsi) dans al
-    cmp [rdi + rbx], al ; je compare les deux caracters actuel
-    jne .err ; si != je renvoie err
-    inc rbx ; incremente rbx (index)
-    jmp .loop ; je refais un tour
+    movzx eax, byte [rdi]       ; s1[i]
+    movzx edx, byte [rsi]       ; s2[i]
+    cmp eax, edx                ; check si s1[i] == s2[i]
+    jne .err                    ; si je suis dessus je passe a l'etape suivante
+    test eax, eax               ; check si s1[i] == 0
+    je .done                    ; si != je renvoie err
+    inc rdi                     ; s1++
+    inc rsi                     ; s2++
+    jmp .loop                   ; je refais un tour
 
   .done: 
-    pop rbx
-    mov rax, 0
+    xor rax, rax                ; return 0
     ret
 
   .err:
-    mov rax, [rdi + rbx]
-    sub rax, [rsi + rbx] ; dest = dest - src
-    pop rbx
+    sub eax, edx                ; dest = dest - src
     ret

--- a/ft_strdup.s
+++ b/ft_strdup.s
@@ -1,0 +1,32 @@
+bits 64
+global ft_strdup
+
+extern __errno_location
+extern malloc
+extern ft_strlen
+extern ft_strcpy
+
+section .text
+  ft_strdup:
+    test    rdi, rdi
+    jz      .null
+
+    push    rdi               ; on garde s et on aligne la stack 
+    call    ft_strlen
+    inc     rax               ; +1 pour \0
+    mov     rdi, rax          ; on deplace la taille de s dans rdi pour malloc
+    call    malloc wrt ..plt
+    test    rax, rax          ; check si on recois NULL
+    jz      .fail
+
+    pop     rsi               ; restaurer s
+    mov     rdi, rax          ; dest
+    call    ft_strcpy
+    ret
+
+  .fail:
+      add     rsp, 8            ; on simule un pop (realignement de la stack)
+  .null:
+      xor     rax, rax
+      ret
+

--- a/ft_strdup.s
+++ b/ft_strdup.s
@@ -25,7 +25,10 @@ section .text
     ret
 
   .fail:
-      add     rsp, 8            ; on simule un pop (realignement de la stack)
+      add     rsp, 8          ; on simule un pop (realignement de la stack)
+      call __errno_location wrt ..plt; __errno_location renvoie l'adrress de errno dans rax
+      mov dword [rax], edi    ; on assigne la -valeur retourner par sys_write a errno
+
   .null:
       xor     rax, rax
       ret

--- a/tests/test.c
+++ b/tests/test.c
@@ -4,6 +4,15 @@
 #include <string.h>
 #include <unistd.h>
 
+#define RESET "\033[0m"
+#define RED "\033[31m"
+#define GREEN "\033[32m"
+#define YELLOW "\033[33m"
+#define BLUE "\033[34m"
+#define MAGENTA "\033[35m"
+#define CYAN "\033[36m"
+#define BOLD "\033[1m"
+
 size_t ft_strlen(const char *str);
 char *ft_strcpy(char *dest, const char *src);
 int ft_strcmp(const char *s1, const char *s2);
@@ -14,9 +23,9 @@ char *ft_strdup(const char *s);
 #define ASSERT(a)                                                              \
   {                                                                            \
     if (a) {                                                                   \
-      printf("ok\n");                                                          \
+      printf(GREEN "✔ ok" RESET "\n");                                         \
     } else {                                                                   \
-      printf("failed\n");                                                      \
+      printf(RED "✘ failed" RESET "\n");                                       \
     }                                                                          \
   }
 
@@ -53,33 +62,35 @@ void strcpy_tests() {
                          NULL};
   for (int i = 0; tests[i] != NULL; i++) {
     char *dest = malloc(sizeof(char) * strlen(tests[i]) + 1);
-    strcpy(dest, tests[i]);
+    ft_strcpy(dest, tests[i]);
     printf("%s: ", tests[i]);
     ASSERT(assert_str(dest, tests[i]));
     free(dest);
   }
+
+  printf("too_big_malloc: ");
+  char *dest = malloc(sizeof(char) * strlen(tests[4]) + 10);
+  ft_strcpy(dest, tests[4]);
+  ASSERT(assert_str(dest, tests[4]));
+  free(dest);
   printf("\n");
 }
 
 void strcmp_tests() {
   printf("--------[STRCMP_TESTS]--------\n");
-  const char *tests[] = {"",
-                         "a",
-                         "hello",
-                         "oui je test",
-                         "longue chaine avec beaucoup de caracteres...",
-                         NULL};
+  const char *tests[] = {
+      "",      "a",           "hello",
+      "jello", "oui je test", "longue chaine avec beaucoup de caracteres...",
+      NULL};
 
-  const char *tests2[] = {"",
-                          "a",
-                          "heilo",
-                          "oui je test",
-                          "longue/chaine avec beaucoup de caracteres...",
-                          NULL};
+  const char *tests2[] = {
+      "",      "a",           "heilo",
+      "hello", "oui je tesx", "longue/chaine avec beaucoup de caracteres...",
+      NULL};
   for (int i = 0; tests[i] != NULL; i++) {
     int mine = ft_strcmp(tests[i], tests2[i]);
     int real = strcmp(tests[i], tests2[i]);
-    printf("%s: ", tests[i]);
+    printf("%s: m %d | r %d", tests[i], mine, real);
     ASSERT(assert_int(mine, real));
   }
   printf("\n");

--- a/tests/test.c
+++ b/tests/test.c
@@ -1,99 +1,88 @@
-#include <stdio.h>
-#include <string.h>
 #include <stddef.h>
+#include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 
-size_t  ft_strlen(const char *str);
-char    *ft_strcpy(char *dest, const char *src);
-int     ft_strcmp(const char *s1, const char *s2);
+size_t ft_strlen(const char *str);
+char *ft_strcpy(char *dest, const char *src);
+int ft_strcmp(const char *s1, const char *s2);
 ssize_t ft_write(int fd, const void *buf, size_t count);
 ssize_t ft_read(int fd, void *buf, size_t count);
+char *ft_strdup(const char *s);
 
-#define ASSERT(a) { \
-  if (a) { printf("ok\n"); } else { printf("failed\n");} \
-}
+#define ASSERT(a)                                                              \
+  {                                                                            \
+    if (a) {                                                                   \
+      printf("ok\n");                                                          \
+    } else {                                                                   \
+      printf("failed\n");                                                      \
+    }                                                                          \
+  }
 
-int assert_int(int a, int b) {
-  return a == b;
-}
-
-int assert_str(const char *a, const char *b) {
-  return strcmp(a, b) == 0;
-}
-
-int assert_cmp(int a, int b) {
-  return a == 0 && b == 0;
-}
-
+int assert_int(int a, int b) { return a == b; }
+int assert_str(const char *a, const char *b) { return strcmp(a, b) == 0; }
+int assert_cmp(int a, int b) { return a == 0 && b == 0; }
 
 void strlen_tests() {
 
   printf("--------[STRLEN_TESTS]--------\n");
-  const char *tests[] = {
-        "",
-        "a",
-        "hello",
-        "oui je test",
-        "longue chaine avec beaucoup de caracteres...",
-        NULL
-    };
+  const char *tests[] = {"",
+                         "a",
+                         "hello",
+                         "oui je test",
+                         "longue chaine avec beaucoup de caracteres...",
+                         NULL};
 
-    for (int i = 0; tests[i] != NULL; i++) {
-        size_t mine = ft_strlen(tests[i]);
-        size_t real = strlen(tests[i]);
-        printf("%s: ", tests[i]);
-        ASSERT(assert_int(real, mine));
-    }
-    printf("\n");
+  for (int i = 0; tests[i] != NULL; i++) {
+    size_t mine = ft_strlen(tests[i]);
+    size_t real = strlen(tests[i]);
+    printf("%s: ", tests[i]);
+    ASSERT(assert_int(real, mine));
+  }
+  printf("\n");
 }
 
 void strcpy_tests() {
   printf("--------[STRCPY_TESTS]--------\n");
-  const char *tests[] = {
-        "",
-        "a",
-        "hello",
-        "oui je test",
-        "longue chaine avec beaucoup de caracteres...",
-        NULL
-    };
-    for (int i = 0; tests[i] != NULL; i++) {
-        char *dest = malloc(sizeof(char) * strlen(tests[i]));
-        ft_strcpy(dest, tests[i]);
-        printf("%s: ", tests[i]);
-        ASSERT(assert_str(dest, tests[i]));
-        free(dest);
-    }
-    printf("\n");
+  const char *tests[] = {"",
+                         "a",
+                         "hello",
+                         "oui je test",
+                         "longue chaine avec beaucoup de caracteres...",
+                         NULL};
+  for (int i = 0; tests[i] != NULL; i++) {
+    char *dest = malloc(sizeof(char) * strlen(tests[i]) + 1);
+    strcpy(dest, tests[i]);
+    printf("%s: ", tests[i]);
+    ASSERT(assert_str(dest, tests[i]));
+    free(dest);
+  }
+  printf("\n");
 }
 
 void strcmp_tests() {
   printf("--------[STRCMP_TESTS]--------\n");
-  const char *tests[] = {
-        "",
-        "a",
-        "hello",
-        "oui je test",
-        "longue chaine avec beaucoup de caracteres...",
-        NULL
-    };
+  const char *tests[] = {"",
+                         "a",
+                         "hello",
+                         "oui je test",
+                         "longue chaine avec beaucoup de caracteres...",
+                         NULL};
 
-    const char *tests2[] = {
-        "",
-        "a",
-        "heilo",
-        "oui je test",
-        "longue/chaine avec beaucoup de caracteres...",
-        NULL
-    };
-    for (int i = 0; tests[i] != NULL; i++) {
-        int mine = ft_strcmp(tests[i], tests2[i]);
-        int real = strcmp(tests[i], tests2[i]);
-        printf("%s: ", tests[i]);
-        ASSERT(assert_int(mine, real));
-    }
-    printf("\n");
+  const char *tests2[] = {"",
+                          "a",
+                          "heilo",
+                          "oui je test",
+                          "longue/chaine avec beaucoup de caracteres...",
+                          NULL};
+  for (int i = 0; tests[i] != NULL; i++) {
+    int mine = ft_strcmp(tests[i], tests2[i]);
+    int real = strcmp(tests[i], tests2[i]);
+    printf("%s: ", tests[i]);
+    ASSERT(assert_int(mine, real));
+  }
+  printf("\n");
 }
 
 #include <fcntl.h>
@@ -101,38 +90,35 @@ void strcmp_tests() {
 void test_write() {
   int fd = open("/dev/null", O_WRONLY);
   printf("--------[WRITE_TESTS]--------\n");
-  const char *tests[] = {
-        "",
-        "a",
-        "hello",
-        "oui je test",
-        "longue chaine avec beaucoup de caracteres...",
-        NULL
-    };
-    for (int i = 0; tests[i] != NULL; i++) {
-        int mine = ft_write(fd, tests[i], ft_strlen(tests[i]));
-        int real= write(fd, tests[i], ft_strlen(tests[i]));
-        printf("%s: ", tests[i]);
-        ASSERT(assert_int(mine, real));
-    }
-    close(fd);
-    fd = open("/dev/null", O_RDONLY);
-    printf("write_in_rdonly_file: ");
-    int mine = ft_write(fd, "ca dois pas marcher", 19);
-    perror("  |__mine errno");
-    int real = write(fd, "ca dois pas marcher", 19);
-    perror("  |__real errno");
+  const char *tests[] = {"",
+                         "a",
+                         "hello",
+                         "oui je test",
+                         "longue chaine avec beaucoup de caracteres...",
+                         NULL};
+  for (int i = 0; tests[i] != NULL; i++) {
+    int mine = ft_write(fd, tests[i], ft_strlen(tests[i]));
+    int real = write(fd, tests[i], ft_strlen(tests[i]));
+    printf("%s: ", tests[i]);
     ASSERT(assert_int(mine, real));
-    close(fd);
-    printf("\n");
+  }
+  close(fd);
+  fd = open("/dev/null", O_RDONLY);
+  printf("write_in_rdonly_file: ");
+  int mine = ft_write(fd, "ca dois pas marcher", 19);
+  perror("  |__mine errno");
+  int real = write(fd, "ca dois pas marcher", 19);
+  perror("  |__real errno");
+  ASSERT(assert_int(mine, real));
+  close(fd);
+  printf("\n");
 }
 
 void test_read() {
-  int fd = open("/dev/null", O_WRONLY);
   printf("--------[READ_TESTS]--------\n");
 
-  int  mine_fd = open("./tests/read_test_mine.txt", O_RDONLY);
-  int  real_fd = open("./tests/read_test_real.txt", O_RDONLY);
+  int mine_fd = open("./tests/read_test_mine.txt", O_RDONLY);
+  int real_fd = open("./tests/read_test_real.txt", O_RDONLY);
   char mine_buf[20] = {0};
   char real_buf[20] = {0};
 
@@ -155,7 +141,7 @@ void test_read() {
   perror("\treal errno");
   ASSERT(assert_int(mine, real));
   (close(mine_fd), close(real_fd));
-  
+
   printf("read_in_invalid fd: ");
   mine = ft_read(mine_fd, mine_buf, 15);
   perror("  |__mine errno");
@@ -166,12 +152,31 @@ void test_read() {
   printf("\n");
 }
 
+void strdup_tests() {
+  printf("--------[STRDUP_TESTS]--------\n");
+  const char *tests[] = {"oui",
+                         "a",
+                         "hello",
+                         "oui je test",
+                         "longue chaine avec beaucoup de caracteres...",
+                         NULL};
+
+  for (int i = 0; tests[i] != NULL; i++) {
+    char *mine = ft_strdup(tests[i]);
+    char *real = strdup(tests[i]);
+    printf("%s: ", tests[i]);
+    ASSERT(assert_str(mine, real));
+    (free(real), free(mine));
+  }
+  printf("\n");
+}
 
 int main(void) {
-    strlen_tests();
-    strcpy_tests();
-    strcmp_tests();
-    test_write();
-    test_read();
-    return 0;
+  strlen_tests();
+  strcpy_tests();
+  strcmp_tests();
+  test_write();
+  test_read();
+  strdup_tests();
+  return 0;
 }


### PR DESCRIPTION
This pull request adds a new `ft_strdup` implementation, updates the build system to include it, and enhances the test suite with more robust and colorful output. It also refactors the `ft_strcmp` assembly for correctness and efficiency, and improves the coverage and clarity of the test cases.

**Feature Addition**
* Added a new assembly implementation for `ft_strdup` in `ft_strdup.s`, including proper error handling and memory allocation logic.
* Included `ft_strdup.s` in the `SRCS` variable in `Makefile` to ensure it is built and linked as part of the library.

**Testing Improvements**
* Enhanced `tests/test.c` with colored output for test results, improved assertion macros, and added comprehensive tests for `ft_strdup`. [[1]](diffhunk://#diff-0f53cf59b46f297ca0eb3cc60bfe24807d5f39fa4a9577c0c0d375fcb51115f7L1-R44) [[2]](diffhunk://#diff-0f53cf59b46f297ca0eb3cc60bfe24807d5f39fa4a9577c0c0d375fcb51115f7R166-R191)
* Added new test targets `dtests` (run under gdb) and `vtests` (run under valgrind) to `Makefile` for easier debugging and memory leak detection.
* Expanded and corrected test cases for `ft_strcpy`, `ft_strcmp`, and `ft_write` to ensure proper memory allocation and comparison coverage. [[1]](diffhunk://#diff-0f53cf59b46f297ca0eb3cc60bfe24807d5f39fa4a9577c0c0d375fcb51115f7L53-R93) [[2]](diffhunk://#diff-0f53cf59b46f297ca0eb3cc60bfe24807d5f39fa4a9577c0c0d375fcb51115f7L104-R109) [[3]](diffhunk://#diff-0f53cf59b46f297ca0eb3cc60bfe24807d5f39fa4a9577c0c0d375fcb51115f7L131)

**Assembly Refactor**
* Refactored `ft_strcmp.s` for correctness, efficiency, and clarity, removing unnecessary register usage and aligning logic with standard `strcmp` behavior.